### PR TITLE
Fix escaping some classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,10 +103,7 @@ function compileAttrs(attrs, options) {
     } else {
       classes = classes.map(function (cls, i) {
         if (isConstant(cls)) {
-          cls = stringify(runtime.classes(
-            [toConstant(cls)],
-            classEscaping[i]
-          ));
+          cls = stringify(classEscaping[i] ? runtime.escape(toConstant(cls)) : toConstant(cls));
           classEscaping[i] = false;
         }
         return cls;

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,7 @@ withOptions({terse: true, format: 'html', runtime: function (name) { return 'jad
   test([{name: 'class', val: '"foo"', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], ' class="foo bar baz"');
   test([{name: 'class', val: '{foo: foo}', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], ' class="foo bar baz"', {foo: true});
   test([{name: 'class', val: '{foo: foo}', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], ' class="bar baz"', {foo: false});
+  test([{name: 'class', val: 'foo', escaped: true}, {name: 'class', val: '"<str>"', escaped: true}], ' class="&lt;foo&gt; &lt;str&gt;"', {foo: '<foo>'});
   test([{name: 'foo', val: '"<foo>"', escaped: false}], ' foo="<foo>"');
   test([{name: 'foo', val: '"<foo>"', escaped: true}], ' foo="&lt;foo&gt;"');
   test([{name: 'foo', val: 'foo', escaped: false}], ' foo="<foo>"', {foo: '<foo>'});
@@ -70,6 +71,7 @@ withOptions({terse: true, format: 'object', runtime: function (name) { return 'j
   test([{name: 'class', val: '"foo"', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], {'class': 'foo bar baz'});
   test([{name: 'class', val: '{foo: foo}', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], {'class': 'foo bar baz'}, {foo: true});
   test([{name: 'class', val: '{foo: foo}', escaped: true}, {name: 'class', val: '["bar", "baz"]', escaped: true}], {'class': 'bar baz'}, {foo: false});
+  test([{name: 'class', val: 'foo', escaped: true}, {name: 'class', val: '"<str>"', escaped: true}], {'class': '&lt;foo&gt; &lt;str&gt;'}, {foo: '<foo>'});
   test([{name: 'foo', val: '"<foo>"', escaped: false}], {foo: "<foo>"});
   test([{name: 'foo', val: '"<foo>"', escaped: true}], {foo: "&lt;foo&gt;"});
   test([{name: 'foo', val: 'foo', escaped: false}], {foo: "<foo>"}, {foo: '<foo>'});


### PR DESCRIPTION
Before this PR,

``` js
[ { name: 'class'
  , val: 'foo'
  , escaped: true
  }
, { name: 'class',
  , val: '"<str>"'
  , escaped: true
  }
]
```

was rendered as (assuming `foo === '<foo>'`):

``` js
' class="&lt;foo&gt; <str>"'
```

After this PR, the output will be

``` js
' class="&lt;foo&gt; &lt;str&gt;"'
```
